### PR TITLE
#505 trigger plugin for workflow

### DIFF
--- a/resources/lang/en/exment.php
+++ b/resources/lang/en/exment.php
@@ -393,6 +393,8 @@ return [
                 'form_menubutton_show' => 'Menu button on Show Data',
                 'form_menubutton_create' => 'Menu button on Form Create View',
                 'form_menubutton_edit' => 'Menu button on Form Edit View',
+                'workflow_action_executing' => 'Before Workflow Action',
+                'workflow_action_executed' => 'After Workflow Action',
             ]
         ],
 

--- a/resources/lang/ja/exment.php
+++ b/resources/lang/ja/exment.php
@@ -393,6 +393,8 @@ return [
                 'form_menubutton_show' => 'データ詳細のメニューボタン',
                 'form_menubutton_create' => 'フォームのメニューボタン（新規作成時）',
                 'form_menubutton_edit' => 'フォームのメニューボタン（更新時）',
+                'workflow_action_executing' => 'ワークフロース実行前',
+                'workflow_action_executed' => 'ワークフロース実行後',
             ]
         ],
 

--- a/src/Controllers/CustomValueController.php
+++ b/src/Controllers/CustomValueController.php
@@ -439,6 +439,7 @@ class CustomValueController extends AdminControllerTableBase
         Plugin::pluginPreparing($this->plugins, 'workflow_action_executing', [
             'custom_table' => $this->custom_table,
             'custom_value' => $custom_value,
+            'workflow_action' => $action,
         ]);
 
         $action->executeAction($custom_value, [
@@ -449,6 +450,7 @@ class CustomValueController extends AdminControllerTableBase
         Plugin::pluginPreparing($this->plugins, 'workflow_action_executed', [
             'custom_table' => $this->custom_table,
             'custom_value' => $custom_value,
+            'workflow_action' => $action,
         ]);
 
         return ([

--- a/src/Controllers/CustomValueController.php
+++ b/src/Controllers/CustomValueController.php
@@ -436,9 +436,19 @@ class CustomValueController extends AdminControllerTableBase
 
         //TODO:validation
         
+        Plugin::pluginPreparing($this->plugins, 'workflow_action_executing', [
+            'custom_table' => $this->custom_table,
+            'custom_value' => $custom_value,
+        ]);
+
         $action->executeAction($custom_value, [
             'comment' => $request->get('comment'),
             'next_work_users' => $request->get('next_work_users'),
+        ]);
+
+        Plugin::pluginPreparing($this->plugins, 'workflow_action_executed', [
+            'custom_table' => $this->custom_table,
+            'custom_value' => $custom_value,
         ]);
 
         return ([

--- a/src/Enums/PluginType.php
+++ b/src/Enums/PluginType.php
@@ -73,7 +73,7 @@ class PluginType extends EnumBase
                 case PluginType::DOCUMENT:
                 case PluginType::TRIGGER:
                     $custom_value = !is_null($options['custom_value']) ? $options['custom_value'] : $options['id'];
-                    return new $classname($plugin, array_get($options, 'custom_table'), $custom_value);
+                    return new $classname($plugin, array_get($options, 'custom_table'), $custom_value, array_get($options, 'workflow_action'));
                 case PluginType::BATCH:
                 case PluginType::PAGE:
                     return new $classname($plugin);

--- a/src/Model/Define.php
+++ b/src/Model/Define.php
@@ -145,6 +145,8 @@ class Define
         'form_menubutton_show',
         'form_menubutton_create',
         'form_menubutton_edit',
+        'workflow_action_executing',
+        'workflow_action_executed',
     ];
 
     /**

--- a/src/Services/Plugin/PluginTriggerBase.php
+++ b/src/Services/Plugin/PluginTriggerBase.php
@@ -15,8 +15,9 @@ class PluginTriggerBase
     //public $custom_form;
     //public $custom_column;
     public $isCreate;
+    public $workflow_action;
 
-    public function __construct($plugin, $custom_table, $custom_value)
+    public function __construct($plugin, $custom_table, $custom_value, $workflow_action)
     {
         $this->plugin = $plugin;
         $this->custom_table = $custom_table;
@@ -27,6 +28,9 @@ class PluginTriggerBase
             $this->custom_value = $custom_table->getValueModel($custom_value);
         }
 
+        if (isset($workflow_action)) {
+            $this->$workflow_action = $workflow_action;
+        }
         $this->isCreate = !isset($custom_value);
     }
 


### PR DESCRIPTION
#505 を実装してみました。
トリガープラグインをワークフローアクションの実行前 or 実行後にも動作させることが目的です。
既存のcustome_table、custome_valueプロパティ加えて、実行されたワークフローアクションのプロパティも参照できるようプロパティ値を追加しました。