### PR TITLE
Hotfix password reset  mail send

### DIFF
--- a/src/Services/NotifyService.php
+++ b/src/Services/NotifyService.php
@@ -392,7 +392,7 @@ class NotifyService
                 }
                 return null;
             }
-        ], $replaceOptions);
+        ], (array)$replaceOptions);
 
         $target = replaceTextFromFormat($target, $custom_value, $replaceOptions);
 


### PR DESCRIPTION
#512 
パスワードリセット時のエラー対応となります。
Model/LoginUserからMailSenderクラスを呼び出す際に、replaceOptionsを渡す方法も考えましたが、ここでは不要のパラメータのため、replaceOptions変数に(array)を付与する形で修正しました。