### PR TITLE
:bug: login_user_default works only create method refs #899

### DIFF
--- a/src/ColumnItems/CustomItem.php
+++ b/src/ColumnItems/CustomItem.php
@@ -315,8 +315,10 @@ abstract class CustomItem implements ItemInterface
         }
 
         // default (login user)
-        if (boolval(array_get($options, 'login_user_default'))) {
-            $field->default(\Exment::getUserId());
+        if ($classname != ExmentField\ViewOnly::class) {
+            if (boolval(array_get($options, 'login_user_default'))) {
+                $field->default(\Exment::getUserId());
+            }
         }
 
         // number_format


### PR DESCRIPTION
Fix bug, `login_user_default` works only create method, not with update method.
Check if create method or update method from class name.

`login_user_default` のオプションが、新規作成・更新に関わらず有効になっている問題を修正。
`初期値をログインユーザーにする` のオプションに該当するので、更新時にこのオプションが有効化しないよう変更。
判断基準はクラス名を利用。

refs #899 