### PR TITLE
:bug: Fix bug refs #933

### DIFF
--- a/src/ColumnItems/CustomColumns/Currency.php
+++ b/src/ColumnItems/CustomColumns/Currency.php
@@ -32,18 +32,15 @@ class Currency extends Decimal
             return [null, null];
         }
 
+        // get digit
+        $digit = array_has($this->custom_column, 'options.decimal_digit') ? intval(array_get($this->custom_column, 'options.decimal_digit')) : 0;
+
         if (boolval(array_get($this->custom_column, 'options.number_format'))
         && is_numeric($v)
         && !boolval(array_get($this->options, 'disable_number_format'))) {
-            if (array_has($this->custom_column, 'options.decimal_digit')) {
-                $digit = intval(array_get($this->custom_column, 'options.decimal_digit'));
-                $value = number_format($v, $digit);
-            //$value = preg_replace("/\.?0+$/",'', $value);
-            } else {
-                $value = number_format($v);
-            }
+            $value = number_format($v, $digit);
         } else {
-            $value = $v;
+            $value = sprintf('%.' . $digit . 'f', $v);
         }
 
         if (boolval(array_get($this->options, 'disable_currency_symbol'))) {


### PR DESCRIPTION
小数点以下が0の場合 ( ex) 19800.0 )、文字列型に変換すると、小数点以下が消えてしまう。
helper側に渡す以前に、文字列型に予め変換しておくよう修正。