### PR TITLE
Fix php-cs-fixer rules and file format.

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()->in([
+    'src/',
+    'tests/',
+]);
+$config = new PhpCsFixer\Config();
+
+return $config
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PhpCsFixer:risky' => false,
+        'blank_line_after_opening_tag' => false,
+        'linebreak_after_opening_tag' => false,
+        'declare_strict_types' => false,
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'none',
+            'sort_algorithm' => 'none',
+        ],
+        'no_superfluous_phpdoc_tags' => false,
+        'php_unit_test_case_static_method_calls' => [
+            'call_type' => 'this'
+        ],
+        'not_operator_with_successor_space' => false,
+        'blank_line_after_namespace' => true,
+    ])
+    ->setFinder($finder);

--- a/document/en/Develop.md
+++ b/document/en/Develop.md
@@ -183,8 +183,7 @@ composer global require friendsofphp/php-cs-fixer
 #Remove unused use
 php-cs-fixer fix ./vendor/exceedone/exment --rules=no_unused_imports
 #Fix all source
-php-cs-fixer fix ./vendor/exceedone/exment/src 
-php-cs-fixer fix ./vendor/exceedone/exment/tests
+php-cs-fixer fix
 ```
 
 

--- a/document/ja/Develop.md
+++ b/document/ja/Develop.md
@@ -193,8 +193,7 @@ composer global require friendsofphp/php-cs-fixer
 # 不要な"use"を削除
 php-cs-fixer fix ./vendor/exceedone/exment --rules=no_unused_imports 
 # すべてのソースを整形
-php-cs-fixer fix ./vendor/exceedone/exment/src
-php-cs-fixer fix ./vendor/exceedone/exment/tests
+php-cs-fixer fix
 ~~~
 
 

--- a/src/Controllers/AuthSamlController.php
+++ b/src/Controllers/AuthSamlController.php
@@ -7,7 +7,6 @@ use Exceedone\Exment\Model\LoginSetting;
 use Exceedone\Exment\Enums\LoginType;
 use Exceedone\Exment\Exceptions\SsoLoginErrorException;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * For login saml controller

--- a/src/Model/CustomRelation.php
+++ b/src/Model/CustomRelation.php
@@ -191,7 +191,7 @@ class CustomRelation extends ModelBase implements Interfaces\TemplateImporterInt
      *
      * @param CustomValue $custom_value
      * @param boolean $isCallAsParent
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany | \Illuminate\Database\Eloquent\Relations\MorphMany | \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany|\Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function getDynamicRelationValue(CustomValue $custom_value, bool $isCallAsParent)
     {

--- a/src/Model/CustomValue.php
+++ b/src/Model/CustomValue.php
@@ -252,7 +252,7 @@ abstract class CustomValue extends ModelBase
      *
      * @param int $custom_relation_id
      * @param boolean $isCallAsParent
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany | \Illuminate\Database\Eloquent\Relations\MorphMany | \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany|\Illuminate\Database\Eloquent\Relations\MorphMany|\Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function getDynamicRelationValue(int $custom_relation_id, bool $isCallAsParent)
     {

--- a/src/Services/Auth2factor/Providers/Email.php
+++ b/src/Services/Auth2factor/Providers/Email.php
@@ -6,7 +6,6 @@ use Exceedone\Exment\Services\Auth2factor\Auth2factorService;
 use Exceedone\Exment\Model\Define;
 use Exceedone\Exment\Auth\ThrottlesLogins;
 use Exceedone\Exment\Enums\MailKeyName;
-use Illuminate\Http\Request;
 use Exceedone\Exment\Controllers\AuthTrait;
 use Carbon\Carbon;
 

--- a/src/Services/Auth2factor/Providers/Google.php
+++ b/src/Services/Auth2factor/Providers/Google.php
@@ -6,7 +6,6 @@ use Exceedone\Exment\Model\System;
 use Exceedone\Exment\Services\Auth2factor\Auth2factorService;
 use Exceedone\Exment\Auth\ThrottlesLogins;
 use Exceedone\Exment\Model\Define;
-use Illuminate\Http\Request;
 use Exceedone\Exment\Controllers\AuthTrait;
 use PragmaRX\Google2FA\Google2FA;
 use Carbon\Carbon;


### PR DESCRIPTION
php-cs-fixerのルール適用時に差分が初期の状態で発生してしまっていたので下記を実施しました。

* `no_unused_imports` を修正
* `.php-cs-fixer.dist.php` ルールの定義ファイルの作成
* 新ルールでも差分が出てしまっている部分についてルールを適用
* 新ルールの実行方法を `Develop.md` に反映