### PR TITLE
Enabled the checkbox to use the Plugin(View)

### DIFF
--- a/src/Enums/PluginType.php
+++ b/src/Enums/PluginType.php
@@ -133,6 +133,7 @@ class PluginType extends EnumBase
             static::EXPORT,
             static::IMPORT,
             static::BUTTON,
+            static::VIEW,
         ];
     }
 


### PR DESCRIPTION
下記の問題を解消するために，役割グループ設定画面における **プラグイン（ビュー）** の「利用・アクセス」チェックボックスを有効にするプルリクエストを提出いたします。

### Describe the bug / バグの説明
プラグイン（ビュー）においてrouteを設定すると，エンドポイントを設定できます。
https://exment.net/docs/#/ja/plugin_quickstart_view?id=configjson%e4%bd%9c%e6%88%90

エンドポイントへアクセスした際に，「システム管理者」権限を持つユーザでは正常にアクセスできるものの，
それ以外のユーザは，テーブルへの編集権限を持っていても，
HTTP 403 エラー（権限がありません）になりアクセスできませんでした。

試行錯誤した結果，役割グループ設定画面のプラグイン（ビュー）の「利用・アクセス」チェックボックスを有効にすると，権限を持つユーザはアクセスできるようになりました。
ただしプラグイン（ビュー）の「利用・アクセス」チェックボックスは，現状では変更不可（無効）になっており変更できません。
そのためチェックボックスを編集可能にする

### To Reproduce / 再現手順

1. テンプレートから「プロジェクト・タスク管理」をインポートする。
2. テーブル「プロジェクト」と「タスク管理」に適当にデータを追加する。
3. プラグイン「かんばんビュー」をアップロードし，対象テーブルを「タスク管理」に設定する。
4. テーブル「タスク管理」のビュー設定から「かんばんビュー」を追加し，カテゴリ列を「ステータス」に設定する。
5. かんばんビューを表示し，タスクを移動する。（データ更新のためエンドポイントにHTTP POST リクエストを送る）
    - 「システム管理者」権限を持つユーザの場合，成功する
    - それ以外のユーザの場合，失敗する

### Version / 発生バージョン
v4.2.7

### Error log / エラーログ
サーバー側(laravel.log)にエラーのログはありませんでした。

失敗した場合のHTTPレスポンス:
```
> POST /admin/plugins/kanban_view/update HTTP/2
 ~省略~
> content-type: application/x-www-form-urlencoded; charset=UTF-8
_token=ypxDm****b&value%5Bstatus%5D=90&id=2&table_name=task

< HTTP/2 403 
< date: Thu, 20 Jan 2022 10:16:53 GMT
< content-type: application/json
< server: nginx/1.21.4
< x-powered-by: PHP/7.4.16
< cache-control: no-cache, private
< 
{
    message: "権限がありません。"
}
```

### Screenshots / スクリーンショット

現状の役割グループ設定画面：
プラグイン（ビュー）の「利用・アクセス」チェックボックスは現状では変更できません。

![変更不可（無効）になっている](https://user-images.githubusercontent.com/8448754/150323762-f079d3a3-8816-46ed-9713-534589bfd202.png)

修正後の役割グループ設定画面：
プラグイン（ビュー）の「利用・アクセス」チェックボックスを有効にしました。

![修正後](https://user-images.githubusercontent.com/8448754/150324075-173fcf60-4d4b-4517-9df3-6e3c873043ca.png)


### Additional context / その他  
なし
