### PR TITLE
Github actionsでphp-cs-fixerの確認を行うように対応

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,10 +1,10 @@
 name: php-cs-fixer
 
-on: [push]
-#  pull_request:
-#    paths:
-#      - './src'
-#      - './tests'
+on:
+  pull_request:
+    paths:
+      - './src'
+      - './tests'
 
 jobs:
   php-cs-fixer:

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,10 +1,10 @@
 name: php-cs-fixer
 
-on:
-  pull_request:
-    paths:
-      - './src'
-      - './tests'
+on: [push]
+#  pull_request:
+#    paths:
+#      - './src'
+#      - './tests'
 
 jobs:
   php-cs-fixer:

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ "7.3", "7.4" ]
+        php: [ "7.2", "7.3", "7.4" ]
     steps:
       - uses: actions/checkout@v2
 
@@ -23,7 +23,7 @@ jobs:
 
       - name: Prepare
         run: |
-          wget https://cs.symfony.com/download/php-cs-fixer-v3.phar -O php-cs-fixer
+          wget https://cs.symfony.com/download/php-cs-fixer-v2.phar -O php-cs-fixer
           chmod a+x php-cs-fixer
 
       - name: Versions
@@ -34,5 +34,5 @@ jobs:
 
       - name: Execute php-cs-fixer
         run: |
-          php php-cs-fixer fix --diff --format txt --verbose --dry-run ./src
-          php php-cs-fixer fix --diff --format txt --verbose --dry-run ./tests
+          php php-cs-fixer fix --dry-run -v --diff --diff-format udiff ./src
+          php php-cs-fixer fix --dry-run -v --diff --diff-format udiff ./tests

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,0 +1,38 @@
+name: php-cs-fixer
+
+on:
+  pull_request:
+    paths:
+      - './src'
+      - './tests'
+
+jobs:
+  php-cs-fixer:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ "7.3", "7.4" ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Prepare
+        run: |
+          wget https://cs.symfony.com/download/php-cs-fixer-v3.phar -O php-cs-fixer
+          chmod a+x php-cs-fixer
+
+      - name: Versions
+        run: |
+          cat /etc/os-release
+          php -v
+          php php-cs-fixer --version
+
+      - name: Execute php-cs-fixer
+        run: |
+          php php-cs-fixer fix --diff --format txt --verbose --dry-run ./src
+          php php-cs-fixer fix --diff --format txt --verbose --dry-run ./tests


### PR DESCRIPTION
exmentがPHPのバージョンにて7.2以上のサポートのようなので
念のため下記のPHPバージョンで実行しています。
https://exment.net/docs/#/ja/server?id=web%e3%82%b5%e3%83%bc%e3%83%90%e3%83%bc

* PHP 7.2
* PHP 7.3
* PHP 7.4