### PR TITLE
php-cs-fixerからワークフローからPHP7.2を除外

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ "7.2", "7.3", "7.4" ]
+        php: [ "7.3", "7.4" ]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
exment v4.4.0でPHP7.2がサポート対象外になったため
php-cs-fixerのgithub actionsのworkflowからPHP7.2をmatrixから削除しました。

https://exment.net/docs/#/ja/server