### PR TITLE
PHP Coding Standards Fixer support PHP 8.0 and 8.1

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -3,8 +3,8 @@ name: php-cs-fixer
 on:
   pull_request:
     paths:
-      - './src'
-      - './tests'
+      - 'src/**'
+      - 'tests/**'
 
 jobs:
   php-cs-fixer:
@@ -12,9 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ "7.3", "7.4" ]
+        php: [ "8.0", "8.1" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
PHP CS Fixerのバージョン自体はv3に上げるとかなりのコードが引っかかるためv2に据え置きました。