### PR TITLE
delete php8.1 from php-cs-fixer workflow.

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ "8.0", "8.1" ]
+        php: [ "8.0" ]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
PHP-CS-FixerがPHP8.1をサポートしていないためワークフローから削除しました。