### PR TITLE
Azule AD(SAML認証)の認証アプリに対応する

### DIFF
--- a/resources/lang/en/exment.php
+++ b/resources/lang/en/exment.php
@@ -882,6 +882,7 @@ return [
         'saml_option_authn_request_signed' => 'Sign AuthnRequest',
         'saml_option_logout_request_signed' => 'Sign LogoutRequest',
         'saml_option_logout_response_signed' => 'Sign LogoutResponse',
+        'saml_option_requested_authn_context' => 'Sign RequestedAuthnContext',
         'saml_option_proxy_vars' => 'Use Proxy',
         
         'ldap_setting' => 'LDAP Setting',
@@ -949,6 +950,7 @@ return [
             'saml_option_authn_request_signed' => 'Set to YES to sign the authentication request sent by the SP.',
             'saml_option_logout_request_signed' => 'Set to YES to sign the logout request sent by the SP.',
             'saml_option_logout_response_signed' => 'Set to YES to sign the logout response sent by the SP.',
+            'saml_option_requested_authn_context' => 'Set to YES to limit the IdP authentication method to password authentication.',
             'saml_option_proxy_vars' => 'Set to YES if use Reverse Proxy.',
             'saml_key_path' => '<br />*When reading from a file, place the file in the following path.<br/>%s',
 

--- a/resources/lang/ja/exment.php
+++ b/resources/lang/ja/exment.php
@@ -882,6 +882,7 @@ return [
         'saml_option_authn_request_signed' => 'Sign AuthnRequest',
         'saml_option_logout_request_signed' => 'Sign LogoutRequest',
         'saml_option_logout_response_signed' => 'Sign LogoutResponse',
+        'saml_option_requested_authn_context' => 'Sign RequestedAuthnContext',
         'saml_option_proxy_vars' => 'Proxy使用',
         
         'ldap_setting' => 'LDAP設定',
@@ -949,6 +950,7 @@ return [
             'saml_option_authn_request_signed' => 'SPによって送信する認証リクエストを署名する場合は、YESにしてください。',
             'saml_option_logout_request_signed' => 'SPによって送信するログアウトリクエストを署名する場合は、YESにしてください。',
             'saml_option_logout_response_signed' => 'SPによって送信するログアウトレスポンスを署名する場合は、YESにしてください。',
+            'saml_option_requested_authn_context' => 'IdPの認証方式をパスワード認証に限定する場合は、YESにしてください。',
             'saml_option_proxy_vars' => 'リバースプロキシなどを使用している場合に、YESにしてください。',
             'saml_key_path' => '<br />※ファイルから読み込みを行う場合、以下のパスにファイルを配置してください。<br/>%s',
 

--- a/src/Model/LoginSetting.php
+++ b/src/Model/LoginSetting.php
@@ -366,7 +366,7 @@ class LoginSetting extends ModelBase
                 'authnRequestsSigned' => boolval($provider->getOption('saml_option_authn_request_signed')) ??  false,
                 'logoutRequestSigned' => boolval($provider->getOption('saml_option_logout_request_signed')) ??  false,
                 'logoutResponseSigned' => boolval($provider->getOption('saml_option_logout_response_signed')) ??  false,
-                'requestedAuthnContext' => boolval($provider->getOption('saml_option_requested authn context')) ??  false,
+                'requestedAuthnContext' => boolval($provider->getOption('saml_option_requested_authn_context')) ??  false,
             ],
         ];
 

--- a/src/Model/LoginSetting.php
+++ b/src/Model/LoginSetting.php
@@ -366,6 +366,7 @@ class LoginSetting extends ModelBase
                 'authnRequestsSigned' => boolval($provider->getOption('saml_option_authn_request_signed')) ??  false,
                 'logoutRequestSigned' => boolval($provider->getOption('saml_option_logout_request_signed')) ??  false,
                 'logoutResponseSigned' => boolval($provider->getOption('saml_option_logout_response_signed')) ??  false,
+                'requestedAuthnContext' => boolval($provider->getOption('saml_option_requested authn context')) ??  false,
             ],
         ];
 

--- a/src/Services/Login/Saml/SamlService.php
+++ b/src/Services/Login/Saml/SamlService.php
@@ -185,6 +185,11 @@ class SamlService implements LoginServiceInterface
         ->default("0")
         ->attribute(['data-filter' => json_encode(['key' => 'login_type', 'parent' => 1, 'value' => [LoginType::SAML]])]);
 
+        $form->switchbool('saml_option_requested_authn_context', exmtrans("login.saml_option_requested_authn_context"))
+        ->help(exmtrans("login.help.saml_option_requested_authn_context"))
+        ->default("0")
+        ->attribute(['data-filter' => json_encode(['key' => 'login_type', 'parent' => 1, 'value' => [LoginType::SAML]])]);
+
         $form->switchbool('saml_option_proxy_vars', exmtrans("login.saml_option_proxy_vars"))
         ->help(exmtrans("login.help.saml_option_proxy_vars"))
         ->default("0")


### PR DESCRIPTION
Azule ADでSAML認証する場合、認証アプリで認証するとMicrosoft側ログインページで以下のエラーが発生します。
>申し訳ありませんが、サインイン中に問題が発生しました。
>AADSTS75011: Authentication method 'X509, MultiFactor'
>by which the user authenticated with the service doesn't match requested authentication method 'Password,
> ProtectedTransport'. Contact the Exment application owne

パスワード認証に固定されているようなので、SAML設定画面で変更できるようにします。