### PR TITLE
v5.0.4向けのソースコードです。

### DIFF
--- a/config/exment.php
+++ b/config/exment.php
@@ -1066,4 +1066,24 @@ return [
     |
     */
     'show_workflow_id' => env('EXMENT_SHOW_WORKFLOW_ID', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Specifies that the select box of role_group should be sorted by order column
+    |--------------------------------------------------------------------------
+    |
+    | If true, sort select box of organizations by default view.
+    |
+    */
+    'sort_org_by_default_view' => env('EXMENT_SORT_ORG_BY_DEFAULT_VIEW', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Specifies that the select box of role_group should be sorted by order column
+    |--------------------------------------------------------------------------
+    |
+    | If true, sort select box of role_group by order column.
+    |
+    */
+    'sort_role_group_by_order' => env('EXMENT_SORT_ROLE_GROUP_BY_ORDER', false),
 ];

--- a/database/migrations/2022_10_07_000000_role_groups_patch_221007.php
+++ b/database/migrations/2022_10_07_000000_role_groups_patch_221007.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+class RoleGroupsPatch221007 extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('role_groups', function (Blueprint $table) {
+            if (!Schema::hasColumn('role_groups', 'role_group_order')) {
+                $table->integer('role_group_order')->default(0)->after('role_group_view_name');
+            }
+        });
+
+        Schema::table('role_groups', function (Blueprint $table) {
+            $table->index('role_group_order');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::hasTable('role_groups')) {
+            Schema::table('role_groups', function ($table) {
+                if (Schema::hasColumn('role_groups', 'role_group_order')) {
+                    $table->dropColumn('role_group_order');
+                }
+            });
+        }
+    }
+}

--- a/public/vendor/exment/js/customform.js
+++ b/public/vendor/exment/js/customform.js
@@ -710,6 +710,10 @@ var Exment;
                 $('.changedata_column_id').children('option').remove();
                 $('.changedata_column_id').append($('<option>').val('').text(''));
                 $.each(data, function (value, name) {
+                    if(name.view_id) {
+                        value = name.view_id;
+                        name = name.view_name;
+                    }
                     var $option = $('<option>')
                         .val(value)
                         .text(name)

--- a/resources/lang/en/exment.php
+++ b/resources/lang/en/exment.php
@@ -1937,6 +1937,7 @@ return [
         'permission_setting' => 'Permission Setting',
         'user_organization_setting' => 'User/organization setting',
         'users_count' => 'User count',
+        'role_group_order' => 'Order',
         'organizations_count' => 'Organization count',
         'share_description' => 'Share this data with other users and organizations. Sharing enables other users and organizations to access this data.',
         'data_share_description' => 'Share this %1$s with other users and organizations. Sharing enables other users and organizations to access this data.',

--- a/resources/lang/ja/exment.php
+++ b/resources/lang/ja/exment.php
@@ -1938,6 +1938,7 @@ return [
         'permission_setting' => '権限設定',
         'user_organization_setting' => 'ユーザー・組織設定',
         'users_count' => 'ユーザー数',
+        'role_group_order' => '表示順',
         'organizations_count' => '組織数',
         'share_description' => 'このデータを、他のユーザー・組織に共有します。共有することで、他のユーザー・組織が、このデータにアクセスすることができるようになります。',
         'data_share_description' => 'この%1$sを、他のユーザー・組織に共有します。共有することで、他のユーザー・組織が、この%1$sにアクセスすることができるようになります。',

--- a/resources/views/form/field/checkboxtable.blade.php
+++ b/resources/views/form/field/checkboxtable.blade.php
@@ -6,59 +6,104 @@
     </div>
 </div>
 @endif
+<style>
+    div.table-container {
+        border-collapse: collapse;
+    }
+    .border-solid {
+        border: 1px solid #AAAAAA;
+    }
+    .table-section{ display: table; }
+    .table-row { display: table-row; }
+    .table-heading { display: table-header-group;}
+    .table-cell, .table-head { display: table-cell; height: 50px;}
+    .table-heading { display: table-header-group;}
+    .table-foot { display: table-footer-group;}
+    .table-body { display: table-row-group;}
+    .table-label { margin-top: 5px; padding-top: 0;margin-right: 5px}
+    .table-right {
+        padding-right: 0;
+        z-index: 10;
+        left: 1px;
+    }
+    .table-left {
+        padding-left: 0;
+    }
+</style>
 
 <div class="checkboxtable form-group">
-
-<div class="{{$viewClass['label']}}">
-    <div class="checkboxtable-header">
-        &nbsp;
-    </div>
-@foreach($items as $item)
-    <div class="checkboxtable-body text-right {{!is_nullorempty(array_get($item, 'error')) ? 'has-error' : ''}}">
-        <label for="{{$id}}" class="control-label">{{$item['label']}}</label>
-
-        @if(!is_nullorempty(array_get($item, 'error')))
-        <i class="fa fa-exclamation-circle" data-help-text="{{array_get($item, 'error')}}" data-help-title="{{ exmtrans('common.error') }}"></i>
-        @endif
-    </div>
-@endforeach
-</div>
-
-<div class="{{$viewClass['field']}}" style="overflow-y:hidden; overflow-x:auto; white-space: nowrap;">
-    <div class="checkboxtable-header">
-    @foreach($options as $option => $label)
-    <span style="width:{{$checkWidth}}px; display:inline-block; text-align:center; font-size:0.85em;">
-        @if($headerEsacape)
-        {{$label}}
-        @else
-        {!! $label !!}
-        @endif
-
-        @if(!empty($headerHelps[$option]))
-        <br/>
-        <i class="fa fa-info-circle" data-help-text="{{$headerHelps[$option]}}" data-help-title="{{ $label }}"></i>
-        @endif
-    </span>
-    @endforeach
+    <div class="{{$viewClass['label']}} table-right">
+    
+        <div class="checkboxtable-header"></div>
+        <div class="table-section table-container w-100 border-solid">
+            <div class="table-body">
+                @foreach($items as $item)
+                <div class="table-row w-100">
+                    <div class="table-cell border-solid">
+                        <div class="checkboxtable-body text-right {{!is_nullorempty(array_get($item, 'error')) ? 'has-error' : ''}}">
+                            <label for="{{$id}}" class="control-label table-label">{{$item['label']}}</label>
+                    
+                            @if(!is_nullorempty(array_get($item, 'error')))
+                            <i class="fa fa-exclamation-circle" data-help-text="{{array_get($item, 'error')}}" data-help-title="{{ exmtrans('common.error') }}"></i>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+                @endforeach
+            </div>
+        </div>
     </div>
 
-@foreach($items as $item)
-    <div class="checkboxtable-body">
-        @foreach($options as $option => $label)
-            <span class="icheck" style="width:{{$checkWidth}}px; display:inline-block; text-align:center;">
-                <label class="checkbox-inline">
-                    <input type="checkbox" name="{{$item['name']}}[]" value="{{$option}}" class="{{$class}}" {{ in_array($option, (array)old(array_get($item, 'key'), $item['values'])) || ($item['values'] === null && in_array($label, $checked)) ?'checked':'' }} 
-                        {{ in_array($option, array_get($item, 'disables', [])) ? ' disabled' : '' }}  {!! $attributes !!} 
-                    />
-                </label>
-            </span>
-        @endforeach
-
-        <input type="hidden" name="{{$item['name']}}[]">
-
-        @include('admin::form.help-block')
+    <div class="{{$viewClass['field']}} table-left" style="overflow-y:hidden; overflow-x:auto; white-space: nowrap;">
+        <div class="checkboxtable-header">
+            <div class="table-section table-container border-solid">
+                <div class="table-body">
+                    <div class="table-row">
+                        @foreach($options as $option => $label)
+                        <div class="table-cell border-solid">
+                            <span style="width:{{$checkWidth}}px; display:inline-block; text-align:center; font-size:0.85em;">
+                                @if($headerEsacape)
+                                {{$label}}
+                                @else
+                                {!! $label !!}
+                                @endif
+                    
+                                @if(!empty($headerHelps[$option]))
+                                <br/>
+                                <i class="fa fa-info-circle" data-help-text="{{$headerHelps[$option]}}" data-help-title="{{ $label }}"></i>
+                                @endif
+                            </span>
+                        </div>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+        </div>
+    
+        <div class="table-section table-container border-solid">
+            <div class="table-body">
+                @foreach($items as $item)
+                <div class="table-row">
+                    @foreach($options as $option => $label)
+                    <div class="table-cell border-solid">
+                        <span class="icheck" style="width:{{$checkWidth}}px; display:inline-block; text-align:center;">
+                            <label class="checkbox-inline" style="margin-top:5px">
+                                <input type="checkbox" name="{{$item['name']}}[]" value="{{$option}}" class="{{$class}}" {{ in_array($option, (array)old(array_get($item, 'key'), $item['values'])) || ($item['values'] === null && in_array($label, $checked)) ?'checked':'' }} 
+                                    {{ in_array($option, array_get($item, 'disables', [])) ? ' disabled' : '' }}  {!! $attributes !!} 
+                                />
+                            </label>
+                        </span>
+                    </div>
+                    @endforeach
+    
+                    <input type="hidden" name="{{$item['name']}}[]">
+    
+                    @include('admin::form.help-block')
+                </div>
+                @endforeach
+            </div>
+        </div>
+    
     </div>
-@endforeach
-</div>
 
 </div>

--- a/resources/views/plugin/editor/code.blade.php
+++ b/resources/views/plugin/editor/code.blade.php
@@ -1,6 +1,11 @@
 <div class="form-group ">
     <span>{{$filepath}}</span>
 </div>
+<style>
+    .CodeMirror {
+        height: 78vh;
+    }
+</style>
 <div class="form-group">
     <textarea id="edit_plugin_file" class="form-control">{{$filedata}}</textarea>
 </div>

--- a/src/Controllers/ApiController.php
+++ b/src/Controllers/ApiController.php
@@ -280,7 +280,10 @@ class ApiController extends AdminControllerBase
         if (!isset($select_target_table)) {
             return [];
         }
-        return CustomTable::getEloquent($select_target_table)->custom_columns()->get(['id', 'column_view_name'])->pluck('column_view_name', 'id');
+        return CustomTable::getEloquent($select_target_table)
+            ->custom_columns()
+            ->selectRaw('id as view_id, column_view_name as view_name')
+            ->get();
     }
 
 

--- a/src/Controllers/RoleGroupController.php
+++ b/src/Controllers/RoleGroupController.php
@@ -24,6 +24,7 @@ use Encore\Admin\Layout\Content;
 use Encore\Admin\Grid\Linker;
 use Encore\Admin\Widgets\Box;
 use Encore\Admin\Auth\Permission as Checker;
+use Encore\Admin\Form as AdminForm;
 
 class RoleGroupController extends AdminControllerBase
 {
@@ -44,6 +45,7 @@ class RoleGroupController extends AdminControllerBase
         $grid = new Grid(new RoleGroup());
         $grid->column('role_group_name', exmtrans('role_group.role_group_name'));
         $grid->column('role_group_view_name', exmtrans('role_group.role_group_view_name'));
+        $grid->column('role_group_order', exmtrans('role_group.role_group_order'))->sortable()->editable();
         $grid->column('role_group_users', exmtrans('role_group.users_count'))->display(function ($counts) {
             return is_null($counts) ? null : count($counts);
         });
@@ -170,6 +172,8 @@ class RoleGroupController extends AdminControllerBase
             ->disable(!$enable)
             ->rows(3);
 
+        $form->number('role_group_order', exmtrans("role_group.role_group_order"))->rules("integer");
+
         $form->exmheader(exmtrans('role_group.role_type_options.' . RoleGroupType::SYSTEM()->lowerKey()) . exmtrans('role_group.permission_setting'))->hr();
 
         $form->descriptionHtml(exmtrans('role_group.description_system_admin'));
@@ -190,7 +194,7 @@ class RoleGroupController extends AdminControllerBase
         $form->checkboxTable("system_permission_permissions", "")
             ->options(RoleGroupType::SYSTEM()->getRoleGroupOptions())
             ->disable(!$enable)
-            ->checkWidth(120)
+            ->checkWidth(150)
             ->headerHelp(RoleGroupType::SYSTEM()->getRoleGroupHelps())
             ->items($items)
             ->setWidth(10, 2);
@@ -214,7 +218,7 @@ class RoleGroupController extends AdminControllerBase
         $form->checkboxTable("role_permission_permissions", "")
             ->options(RoleGroupType::ROLE_GROUP()->getRoleGroupOptions())
             ->disable(!$enable)
-            ->checkWidth(120)
+            ->checkWidth(150)
             ->headerHelp(RoleGroupType::ROLE_GROUP()->getRoleGroupHelps())
             ->items($items)
             ->setWidth(10, 2);
@@ -286,7 +290,7 @@ class RoleGroupController extends AdminControllerBase
         $form->checkboxTable("master_permission_permissions", "")
             ->options(RoleGroupType::MASTER()->getRoleGroupOptions())
             ->disable(!$enable)
-            ->checkWidth(100)
+            ->checkWidth(150)
             ->headerHelp(RoleGroupType::MASTER()->getRoleGroupHelps())
             ->items($items)
             ->setWidth(10, 2);
@@ -316,7 +320,7 @@ class RoleGroupController extends AdminControllerBase
         $form->checkboxTable("table_permission_permissions", "")
             ->options(RoleGroupType::TABLE()->getRoleGroupOptions())
             ->disable(!$enable)
-            ->checkWidth(100)
+            ->checkWidth(150)
             ->headerHelp(RoleGroupType::TABLE()->getRoleGroupHelps())
             ->items($items)
             ->headerEsacape(false)
@@ -408,7 +412,19 @@ class RoleGroupController extends AdminControllerBase
      */
     public function update($id)
     {
-        return request()->get('form_type') == 2 ? $this->saveUserOrganization($id) : $this->saveRolePermission($id);
+        if (request()->get('_editable') == 1 && request()->get('_method') == 'PUT') {
+            if (!$this->hasPermission_UserOrganization()) {
+                Checker::error();
+                return false;
+            }
+
+            $model = RoleGroup::findOrFail($id);
+            $form = new AdminForm($model);
+            $form->number('role_group_order', exmtrans("role_group.role_group_order"))->rules("integer");
+            $form->update($id);
+        } else {
+            return request()->get('form_type') == 2 ? $this->saveUserOrganization($id) : $this->saveRolePermission($id);
+        }
     }
 
     /**
@@ -451,6 +467,7 @@ class RoleGroupController extends AdminControllerBase
             }
             $role_group->role_group_view_name = $request->get('role_group_view_name');
             $role_group->description = $request->get('description');
+            $role_group->role_group_order = $request->get('role_group_order');
             $role_group->save();
 
             $items = [

--- a/src/Model/Menu.php
+++ b/src/Model/Menu.php
@@ -191,7 +191,7 @@ class Menu extends AdminMenu implements Interfaces\TemplateImporterInterface
                 default:
                     break;
 
-                // database-row has icon column, set icon
+                    // database-row has icon column, set icon
             }
 
             if (!$result) {

--- a/src/Model/RoleGroup.php
+++ b/src/Model/RoleGroup.php
@@ -102,5 +102,9 @@ class RoleGroup extends ModelBase
             $model->role_group_permissions()->delete();
             $model->role_group_user_organizations()->delete();
         });
+
+        if (config('exment.sort_role_group_by_order', false)) {
+            static::addGlobalScope(new OrderScope('role_group_order'));
+        }
     }
 }

--- a/src/PartialCrudItems/Providers/UserBelongOrganizationItem.php
+++ b/src/PartialCrudItems/Providers/UserBelongOrganizationItem.php
@@ -8,6 +8,7 @@ use Exceedone\Exment\Enums\SystemTableName;
 use Exceedone\Exment\Enums\Permission;
 use Exceedone\Exment\Model\CustomTable;
 use Exceedone\Exment\Model\CustomRelation;
+use Exceedone\Exment\Model\CustomView;
 
 /**
  * Organization item for User
@@ -89,8 +90,15 @@ class UserBelongOrganizationItem extends ProviderBase
 
     protected function setOptions()
     {
-        $this->options = CustomTable::getEloquent(SystemTableName::ORGANIZATION)->getSelectOptions([
+        $custom_table = CustomTable::getEloquent(SystemTableName::ORGANIZATION);
+        if (config('exment.sort_org_by_default_view', false)) {
+            $custom_view = CustomView::getDefault($custom_table);
+        } else {
+            $custom_view = null;
+        }
+        $this->options = $custom_table->getSelectOptions([
             'notAjax' => true,
+            'target_view' => $custom_view
         ]);
     }
 }

--- a/src/Services/ClassBuilder.php
+++ b/src/Services/ClassBuilder.php
@@ -187,7 +187,7 @@ class ClassBuilder
                 ->addProperty("protected", 'table', "'".getDBTableName($table)."'")
                 ->addMethod("public", "getCustomTableNameAttribute()", "return '".$table->table_name."';")
                 //->addProperty("public", 'custom_table_name', "'".$table->table_name."'")
-                ;
+        ;
 
         // set revision property
         $revisionEnabled = boolval($table->getOption('revision_flg', true));

--- a/src/Web/ts/customform.ts
+++ b/src/Web/ts/customform.ts
@@ -714,6 +714,10 @@ namespace Exment {
                     $('.changedata_column_id').children('option').remove();
                     $('.changedata_column_id').append($('<option>').val('').text(''));
                     $.each(data, function (value, name) {
+                        if(name.view_id) {
+                            value = name.view_id;
+                            name = name.view_name;
+                        }
                         var $option = $('<option>')
                             .val(value as string)
                             .text(name)


### PR DESCRIPTION
タイヨー様向け改修。
1. カスタムテーブル「組織」に表示順を付けて、表示順で表示できるように修正。
2. カスタムテーブル「役割グループ」に表示順を付けて、表示順で表示できるように修正。
3. フォーム設定のデータ連動設定の項目「リンク列を選択」で、カスタム列の表示順に並んでいないため、表示順で表示できるよう修正。
4. 「役割グループ設定」のデザインを一部変更。
5. Exment Plugin編集画面を広く表示できるように修正。