### PR TITLE
 不要なignore-phpstanを削除 

### DIFF
--- a/.github/workflows/check-lang.yml
+++ b/.github/workflows/check-lang.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: ./docker-exment/exment-boilerplate/exment
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Docker Compose Version
         run: docker-compose --version

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -15,6 +15,8 @@ jobs:
         php: [ "8.0", "8.1" ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -17,19 +17,20 @@ jobs:
   phpstan:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ env.DOCKER_EXMENT_REPOSITORY}}
           path: ./docker-exment
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ env.EXMENT_BOILERPLATE_REPOSITORY}}
           path: ./docker-exment/exment-boilerplate
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: ./docker-exment/exment-boilerplate/exment
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Docker Compose Version
         run: docker-compose --version

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,19 +22,20 @@ jobs:
         db: ["mysql", "mariadb", "sqlsrv"]
         test: ["feature", "unit", "browser"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ env.DOCKER_EXMENT_REPOSITORY}}
           path: ./docker-exment
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: ${{ env.EXMENT_BOILERPLATE_REPOSITORY}}
           path: ./docker-exment/exment-boilerplate
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: ./docker-exment/exment-boilerplate/exment
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Docker Compose Version
         run: docker-compose --version

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,3 +4,7 @@ parameters:
     paths:
         - vendor/exceedone/exment
     level: 1
+    ignoreErrors:
+        -
+            message: '#^Method Exceedone\\Exment\\Facades\\ExmentFacade::getFacadeAccessor\(\) should return string but return statement is missing.#'
+            path: vendor/exceedone/exment/src/*

--- a/src/Facades/ExmentFacade.php
+++ b/src/Facades/ExmentFacade.php
@@ -11,8 +11,8 @@ use Illuminate\Support\Facades\Facade;
 class ExmentFacade extends Facade
 {
 
-    protected static function getFacadeAccessor() // @phpstan-ignore-line
+    protected static function getFacadeAccessor()
     {
-        return "\Exceedone\Exment\Exment";// @phpstan-ignore-line
+        return "\Exceedone\Exment\Exment";
     }
 }


### PR DESCRIPTION
phpstanのエラーを修正対応しました。

phpstan-ignore-next-lineをいれるとphpstanエラーがなくなり、入れないとphpstanエラーがでる。

根本的な対応についてはhotfixの対応完了後に対応します。