### PR TITLE
Fix bug condition "not exists" for value multiple

### DIFF
--- a/src/Services/ViewFilter/Items/Exists/ExistsBase.php
+++ b/src/Services/ViewFilter/Items/Exists/ExistsBase.php
@@ -45,15 +45,15 @@ abstract class ExistsBase extends ViewFilterBase
     {
         // if empty array, When isExists is true, return false. not isExists, return true.
         if (is_nullorempty($value)) {
-            return !$this->isExists();
+            return false;
         }
 
         foreach ($value as $v) {
             if (isMatchString($v, $conditionValue)) {
-                return $this->isExists();
+                return true;
             }
         }
-        return !$this->isExists();
+        return false;
     }
 
     abstract protected function isExists(): bool;

--- a/src/Services/ViewFilter/Items/Exists/SelectNotExists.php
+++ b/src/Services/ViewFilter/Items/Exists/SelectNotExists.php
@@ -4,7 +4,7 @@ namespace Exceedone\Exment\Services\ViewFilter\Items\Exists;
 
 use Exceedone\Exment\Enums\FilterOption;
 
-class SelectNotExists extends ExistsBase
+class SelectNotExists extends SelectExists
 {
     public static function getFilterOption()
     {
@@ -14,5 +14,10 @@ class SelectNotExists extends ExistsBase
     protected function isExists(): bool
     {
         return false;
+    }
+
+    public function compareValue($value, $conditionValue): bool
+    {
+        return !parent::compareValue($value, $conditionValue);
     }
 }

--- a/src/Services/ViewFilter/Items/Exists/UserNe.php
+++ b/src/Services/ViewFilter/Items/Exists/UserNe.php
@@ -4,7 +4,7 @@ namespace Exceedone\Exment\Services\ViewFilter\Items\Exists;
 
 use Exceedone\Exment\Enums\FilterOption;
 
-class UserNe extends ExistsBase
+class UserNe extends UserEq
 {
     public static function getFilterOption()
     {
@@ -14,5 +14,10 @@ class UserNe extends ExistsBase
     protected function isExists(): bool
     {
         return false;
+    }
+
+    public function compareValue($value, $conditionValue): bool
+    {
+        return !parent::compareValue($value, $conditionValue);
     }
 }

--- a/tests/Unit/ConditionTest.php
+++ b/tests/Unit/ConditionTest.php
@@ -592,11 +592,12 @@ class ConditionTest extends UnitTestBase
     public function testColumnSelectNotExistsTrue()
     {
         $this->_testColumnSelect('bar', ["baz", null, '', 0, 123], FilterOption::SELECT_NOT_EXISTS, true);
+        $this->_testColumnSelect(123, [111, '234', [456, 789]], FilterOption::SELECT_NOT_EXISTS, true);
     }
     public function testColumnSelectNotExistsFalse()
     {
         $this->_testColumnSelect('foo', ['foo'], FilterOption::SELECT_NOT_EXISTS, false);
-        $this->_testColumnSelect(123, [123, '123'], FilterOption::SELECT_NOT_EXISTS, false);
+        $this->_testColumnSelect(123, [123, '123', [456, 123]], FilterOption::SELECT_NOT_EXISTS, false);
     }
 
     public function testColumnSelectNotNullTrue()

--- a/tests/Unit/ConditionTest.php
+++ b/tests/Unit/ConditionTest.php
@@ -649,17 +649,17 @@ class ConditionTest extends UnitTestBase
     }
     public function testColumnSelectMultiNotExistsTrue()
     {
-        $this->_testColumnSelectMulti(['foo', 'bar'], ['baz', null, 0], FilterOption::SELECT_NOT_EXISTS, true);
-        $this->_testColumnSelectMulti([123, 456, 789], [234, '567', [777]], FilterOption::SELECT_NOT_EXISTS, true);
+        $this->_testColumnSelectMulti(['foo', 'bar'], ['baz', null, 0, ['aaa', 'bbb']], FilterOption::SELECT_NOT_EXISTS, true);
+        $this->_testColumnSelectMulti([123, 456, 789], [234, '567', [777, 999]], FilterOption::SELECT_NOT_EXISTS, true);
         $this->_testColumnSelectMulti(['イタリア', 'カナダ'], [
-            '日本', ['イタリア', '中国'], ['アメリカ', 'カナダ']], FilterOption::SELECT_NOT_EXISTS, true, TestDefine::TESTDATA_TABLE_NAME_UNICODE_DATA);
+            '日本', ['フランス', '中国'], ['アメリカ', '韓国', 'イギリス']], FilterOption::SELECT_NOT_EXISTS, true, TestDefine::TESTDATA_TABLE_NAME_UNICODE_DATA);
     }
     public function testColumnSelectMultiNotExistsFalse()
     {
-        $this->_testColumnSelectMulti(['foo', 'bar'], ['foo', 'bar', ['foo', 'bar']], FilterOption::SELECT_NOT_EXISTS, false);
-        $this->_testColumnSelectMulti([123, 456, 789], [123, '123', [123, 456], [789, 123]], FilterOption::SELECT_NOT_EXISTS, false);
+        $this->_testColumnSelectMulti(['foo', 'bar'], ['foo', 'bar', ['foo', 'baz']], FilterOption::SELECT_NOT_EXISTS, false);
+        $this->_testColumnSelectMulti([123, 456, 789], [123, '123', [123, 456], [789, 111]], FilterOption::SELECT_NOT_EXISTS, false);
         $this->_testColumnSelectMulti(['イタリア', 'カナダ'], [
-            ['イタリア', 'カナダ']], FilterOption::SELECT_NOT_EXISTS, false, TestDefine::TESTDATA_TABLE_NAME_UNICODE_DATA);
+            'カナダ', ['イタリア', 'カナダ'], ['アメリカ', 'カナダ', '中国']], FilterOption::SELECT_NOT_EXISTS, false, TestDefine::TESTDATA_TABLE_NAME_UNICODE_DATA);
     }
     public function testColumnSelectMultiNotNullTrue()
     {
@@ -1129,11 +1129,11 @@ class ConditionTest extends UnitTestBase
     }
     public function testColumnUserMultiNeTrue()
     {
-        $this->_testColumnUserMulti([123, 456, 789], [234, '567', null, 0, [777]], FilterOption::USER_NE, true);
+        $this->_testColumnUserMulti([123, 456, 789], [234, '567', null, 0, [777], [111, 222]], FilterOption::USER_NE, true);
     }
     public function testColumnUserMultiNeFalse()
     {
-        $this->_testColumnUserMulti([123, 456, 789], [123, '123', [123, 456], [789, 123]], FilterOption::USER_NE, false);
+        $this->_testColumnUserMulti([123, 456, 789], [123, '123', [123, 456], [333, 789]], FilterOption::USER_NE, false);
     }
     public function testColumnUserMultiNotNullTrue()
     {


### PR DESCRIPTION
## 実施タスク

特になし

## 実施内容

- 「フォーム優先順位設定」で以下の条件の場合、想定した判定結果とならない
  - 条件：検索値を含まない
  - 条件値：複数指定
- 同様に、「ワークフローのアクション設定の条件設定」、「カスタムテーブルのデータ更新設定の更新条件」

## レビューして欲しいこと

- [x] 「フォーム優先順位設定」の判定結果
- [x] 「ワークフローのアクション設定の条件設定」の判定結果
- [x] 「カスタムテーブルのデータ更新設定の更新条件」の判定結果
- [x] 上記のそれぞれについて　条件地：個別（１つ）指定　の判定結果（デグレードチェック）