### PR TITLE
fix bug for change password reset table

### DIFF
--- a/src/Enums/SystemTableName.php
+++ b/src/Enums/SystemTableName.php
@@ -30,7 +30,7 @@ class SystemTableName extends EnumBase
     public const CUSTOM_VALUE_AUTHORITABLE = 'custom_value_authoritables';
     public const EMAIL_CODE_VERIFY = 'email_code_verifies';
     public const NOTIFY_NAVBAR = 'notify_navbars';
-    public const PASSWORD_RESET = 'password_resets';
+    public const PASSWORD_RESET = 'password_reset_tokens';
     public const REVISION = 'revisions';
     public const LOGIN_SETTINGS = 'login_settings';
     public const WORKFLOW_AUTHORITY = 'workflow_authorities';

--- a/src/Middleware/Initialize.php
+++ b/src/Middleware/Initialize.php
@@ -106,7 +106,7 @@ class Initialize
         if (!Config::has('auth.passwords.exment_admins')) {
             Config::set('auth.passwords.exment_admins', [
                 'provider' => 'exment-auth',
-                'table' => 'password_resets',
+                'table' => 'password_reset_tokens',
                 'expire' => 720,
             ]);
         }


### PR DESCRIPTION
## 実施タスク

特になし

## 実施内容

- パスワードリセットを行おうとすると505エラーになる
「password_resets' doesn't exist」
- Laravel9以降、パスワードリセットテーブル名が変更になったため

## レビューして欲しいこと

- [x] Exment v5.0.0 を新規にインストールしてパスワードリセットを実施