### PR TITLE
Bug fixes in the case setValueStrictly -> validateValue -> validatorU…

### DIFF
--- a/src/Model/CustomTable.php
+++ b/src/Model/CustomTable.php
@@ -786,6 +786,7 @@ class CustomTable extends ModelBase implements Interfaces\TemplateImporterInterf
         }
 
         $errors = [];
+        if( isset($input['value']) ) $input = $input['value'];
 
         $custom_column_names = $this->custom_columns_cache->map(function ($custom_column) {
             return $custom_column->column_name;


### PR DESCRIPTION
## 実施タスク

なし

## 実施内容

- `setValuesStrictly` 呼び出し後に実行される `validatorUnnecessaryColumn` が正しく処理されないのを修正
   - カスタム列の値の持ち方、連想配列の階層の前提が、呼び出し元と呼び出し先で異なる
      - setValuesStrictly > 第1階層 : key = value
      - validatorUnnecessaryColumn > 第1階層 : 'value' = 配列、第2階層 : key = value

## レビューして欲しいこと

- [ ] 保存での必須カスタム列のバリデーション
   - [ ] カスタムフォームから保存
   - [ ] プラグインでの`setValuesStrictly`による保存