### PR TITLE
Single logout with oauth

### DIFF
--- a/resources/lang/en/exment.php
+++ b/resources/lang/en/exment.php
@@ -865,6 +865,9 @@ return [
         'oauth_client_secret' => 'Client Secret',
         'oauth_scope' => 'Scope',
         
+        'oauth_option' => 'Option Setting',         
+        'oauth_option_single_logout' => 'Single Logout',
+        
         'user_setting' => 'User Setting',
         'mapping_user_column' => 'Account Search Column',
         'mapping_setting' => 'Mapping Setting',
@@ -943,6 +946,8 @@ return [
             'jit_rolegroups' => 'Please fill in if you want to assign a default role group when creating a new user.',
             'mapping_description' => 'The field name returned by the provider must match the user field name in Exment. Please enter the field name returned from the provider. <br/>If you enter multiple values ​​separated by commas, the fields that have values ​​will be retrieved with priority from the beginning. <br /> Also, if you want to combine multiple fields, type "${Field_Name}". (Example: ${last_name} ${first_name})',
             'login_test_sso' => 'The :login_type redirect URL for testing.<span class="red">*When performing the test, temporarily add or change the above URL to the callback URL of the provider\'s :login_type setting.</span>',
+                
+            'oauth_option_single_logout' => 'Set to Yes if you want to log out not only from Exment but also from the ID provider',
                 
             'ldap_base_dn' => 'Enter the basic DN (distinguished name) used for authentication.',
             'ldap_filter' => 'Enter the attributes and attribute values ​​used for openLDAP authentication. (Ex: (objectClass=inetOrgPerson)(objectClass=person))',

--- a/resources/lang/en/exment.php
+++ b/resources/lang/en/exment.php
@@ -947,7 +947,7 @@ return [
             'mapping_description' => 'The field name returned by the provider must match the user field name in Exment. Please enter the field name returned from the provider. <br/>If you enter multiple values ​​separated by commas, the fields that have values ​​will be retrieved with priority from the beginning. <br /> Also, if you want to combine multiple fields, type "${Field_Name}". (Example: ${last_name} ${first_name})',
             'login_test_sso' => 'The :login_type redirect URL for testing.<span class="red">*When performing the test, temporarily add or change the above URL to the callback URL of the provider\'s :login_type setting.</span>',
                 
-            'oauth_option_single_logout' => 'Set to Yes if you want to log out not only from Exment but also from the ID provider',
+            'oauth_option_single_logout' => 'Set to Yes if you want to log out not only from Exment but also from the ID provider.<span class="red">*Okta is not supported.</span>',
                 
             'ldap_base_dn' => 'Enter the basic DN (distinguished name) used for authentication.',
             'ldap_filter' => 'Enter the attributes and attribute values ​​used for openLDAP authentication. (Ex: (objectClass=inetOrgPerson)(objectClass=person))',

--- a/resources/lang/ja/exment.php
+++ b/resources/lang/ja/exment.php
@@ -864,6 +864,9 @@ return [
         'oauth_client_id' => 'クライアントID',
         'oauth_client_secret' => 'クライアントシークレット',
         'oauth_scope' => 'スコープ',
+
+        'oauth_option' => 'オプション設定',         
+        'oauth_option_single_logout' => 'シングル・サインアウト',
         
         'user_setting' => 'ユーザー設定',
         'mapping_user_column' => 'アカウント検索列',
@@ -943,7 +946,9 @@ return [
             'jit_rolegroups' => '新規ユーザー作成時に、既定の役割グループを割り振りたい場合は記入してください。',
             'mapping_description' => 'プロバイダから返却されるフィールド名と、Exmentのユーザーフィールド名を合致させる必要があります。プロバイダから返却されるフィールド名を入力してください。<br/>カンマ区切りで複数入力した場合、値の存在するフィールドを、先頭から優先して取得します。<br />また、複数のフィールドを結合したい場合、"${フィールド名}"と入力してください。(例：${last_name} ${first_name})',
             'login_test_sso' => 'テスト用の:login_typeリダイレクトURLです。<span class="red">※テスト実施時には、プロバイダの:login_type設定のコールバックURLに、上記のURLを、一時的に追加もしくは変更してください。</span>',
-                
+
+            'oauth_option_single_logout' => 'Exmentだけでなく、IDプロバイダーからもログアウトする場合は、YESにしてください。',
+            
             'ldap_base_dn' => '認証に使用する基本DN(識別名)を入力してください。',
             'ldap_filter' => 'openLDAPの認証時に利用する、属性と属性値を入力してください。(例：(objectClass=inetOrgPerson)(objectClass=person))',
             'ldap_search_key' => '認証時に使用する、ログインコードの属性を入力してください。',

--- a/resources/lang/ja/exment.php
+++ b/resources/lang/ja/exment.php
@@ -947,7 +947,7 @@ return [
             'mapping_description' => 'プロバイダから返却されるフィールド名と、Exmentのユーザーフィールド名を合致させる必要があります。プロバイダから返却されるフィールド名を入力してください。<br/>カンマ区切りで複数入力した場合、値の存在するフィールドを、先頭から優先して取得します。<br />また、複数のフィールドを結合したい場合、"${フィールド名}"と入力してください。(例：${last_name} ${first_name})',
             'login_test_sso' => 'テスト用の:login_typeリダイレクトURLです。<span class="red">※テスト実施時には、プロバイダの:login_type設定のコールバックURLに、上記のURLを、一時的に追加もしくは変更してください。</span>',
 
-            'oauth_option_single_logout' => 'Exmentだけでなく、IDプロバイダーからもログアウトする場合は、YESにしてください。',
+            'oauth_option_single_logout' => 'Exmentだけでなく、IDプロバイダーからもログアウトする場合は、YESにしてください。<span class="red">※現在、Oktaには対応しておりません。</span>',
             
             'ldap_base_dn' => '認証に使用する基本DN(識別名)を入力してください。',
             'ldap_filter' => 'openLDAPの認証時に利用する、属性と属性値を入力してください。(例：(objectClass=inetOrgPerson)(objectClass=person))',

--- a/src/Controllers/AuthTrait.php
+++ b/src/Controllers/AuthTrait.php
@@ -72,8 +72,15 @@ trait AuthTrait
                 break;
             case LoginType::OAUTH:
                 $provider_name = $login_user->login_provider;
-                if ( LoginSetting::getOAuthSetting($provider_name)->getOption('oauth_option_single_logout') == 1 ) {
-                    return redirect( LoginSetting::getSocialiteProvider($provider_name)->getLogoutUrl( \URL::route('exment.login') ) );    
+                $oauth_setting = LoginSetting::getOAuthSetting($provider_name);
+
+                // Only if oauth provider type is 'other'
+                // ( Because no other provider type has 'getLogoutUrl' )
+                if ( $oauth_setting->getOption('oauth_provider_type') == 'other' ) {
+                    $socialite_provider = LoginSetting::getSocialiteProvider($provider_name);
+                    if ( $oauth_setting->getOption('oauth_option_single_logout') == 1 && method_exists($socialite_provider, 'getLogoutUrl')  ) {
+                        return redirect( $socialite_provider->getLogoutUrl( \URL::route('exment.login') ) );
+                    }
                 }
                 break;
             default:

--- a/src/Controllers/AuthTrait.php
+++ b/src/Controllers/AuthTrait.php
@@ -66,8 +66,18 @@ trait AuthTrait
 
     protected function logoutSso(Request $request, $login_user, $options = [])
     {
-        if ($login_user->login_type == LoginType::SAML) {
-            return $this->logoutSaml($request, $login_user->login_provider, $options);
+        switch ($login_user->login_type) {
+            case LoginType::SAML:
+                return $this->logoutSaml($request, $login_user->login_provider, $options);
+                break;
+            case LoginType::OAUTH:
+                $provider_name = $login_user->login_provider;
+                if ( LoginSetting::getOAuthSetting($provider_name)->getOption('oauth_option_single_logout') == 1 ) {
+                    return redirect( LoginSetting::getSocialiteProvider($provider_name)->getLogoutUrl( \URL::route('exment.login') ) );    
+                }
+                break;
+            default:
+                break;
         }
 
         return redirect(\URL::route('exment.login'));

--- a/src/Controllers/AuthTrait.php
+++ b/src/Controllers/AuthTrait.php
@@ -69,7 +69,6 @@ trait AuthTrait
         switch ($login_user->login_type) {
             case LoginType::SAML:
                 return $this->logoutSaml($request, $login_user->login_provider, $options);
-                break;
             case LoginType::OAUTH:
                 $provider_name = $login_user->login_provider;
                 $oauth_setting = LoginSetting::getOAuthSetting($provider_name);

--- a/src/Services/Login/OAuth/OAuthService.php
+++ b/src/Services/Login/OAuth/OAuthService.php
@@ -148,6 +148,14 @@ class OAuthService implements LoginServiceInterface
                 $form->display('oauth_redirect_url', exmtrans('login.redirect_url'))->default($login_setting->exment_callback_url);
             }
         }
+
+        $form->exmheader(exmtrans('login.saml_option'))->hr()
+        ->attribute(['data-filter' => json_encode(['key' => 'login_type', 'parent' => 1, 'value' => [LoginType::OAUTH]])]);
+
+        $form->switchbool('oauth_option_single_logout', exmtrans("login.oauth_option_single_logout"))
+        ->help(exmtrans("login.help.oauth_option_single_logout"))
+        ->default("0")
+        ->attribute(['data-filter' => json_encode(['key' => 'login_type', 'parent' => 1, 'value' => [LoginType::OAUTH]])]);
     }
 
     /**

--- a/src/Services/Login/OAuth/OAuthService.php
+++ b/src/Services/Login/OAuth/OAuthService.php
@@ -149,13 +149,13 @@ class OAuthService implements LoginServiceInterface
             }
         }
 
-        $form->exmheader(exmtrans('login.saml_option'))->hr()
-        ->attribute(['data-filter' => json_encode(['key' => 'login_type', 'parent' => 1, 'value' => [LoginType::OAUTH]])]);
+        $form->exmheader(exmtrans('login.oauth_option'))->hr()
+        ->attribute(['data-filter' => json_encode(['key' => 'options_oauth_provider_type', 'value' => [LoginProviderType::OTHER]])]);
 
         $form->switchbool('oauth_option_single_logout', exmtrans("login.oauth_option_single_logout"))
         ->help(exmtrans("login.help.oauth_option_single_logout"))
         ->default("0")
-        ->attribute(['data-filter' => json_encode(['key' => 'login_type', 'parent' => 1, 'value' => [LoginType::OAUTH]])]);
+        ->attribute(['data-filter' => json_encode(['key' => 'options_oauth_provider_type', 'value' => [LoginProviderType::OTHER]])]);
     }
 
     /**


### PR DESCRIPTION
## 実施タスク

なし

## 実施内容

- ログイン設定でシングルサインアウト(Single Logout)を指定できるように設定項目を追加
   - ただし、設定値が以下の場合に限る
      - ログイン種類：OAuth認証
      - プロバイダー種類：その他
- SSOでログイン後にログアウトする際、シングルサインアウトの指定がある場合、プロバイダーのログアウト後に、Exmentのログイン画面にリダイレクトするように実装

## レビューして欲しいこと

- [ ] ログイン設定画面
   - [ ] ログイン種類＝OAuth認証、プロバイダー種類：その他　の場合のみ、シングルサインアウトの設定項目が表示される
- [ ] プロバイダー種類
   - [ ] microsoft
   - [ ] graph
      - Repository : exceedone/microsoft-graph, Branch : feature/support_single_logout　をチェックアウトしてください
   - [ ] okta