### PR TITLE
AI: fix bug for AI assistant workflow creation

### DIFF
--- a/src/Controllers/AiAssistantController.php
+++ b/src/Controllers/AiAssistantController.php
@@ -651,27 +651,16 @@ class AiAssistantController extends AdminControllerBase
         $loginUser = \Exment::user();
         $today = \Carbon\Carbon::today()->toDateString();
 
-        // Exclude tables that currently have an active workflow
-        $excludedIds = WorkflowTable::query()
-            ->where('active_flg', 1)
-            ->where(function ($query) use ($today) {
-                $query->whereNull('active_start_date')
-                    ->orWhereDate('active_start_date', '<=', $today);
-            })
-            ->where(function ($query) use ($today) {
-                $query->whereNull('active_end_date')
-                    ->orWhereDate('active_end_date', '>=', $today);
-            })
-            ->whereHas('workflow', function ($query) {
-                $query->where('setting_completed_flg', 1);
-            })
-            ->pluck('custom_table_id')
-            ->unique()
-            ->toArray();
-
         return CustomTable::query()
             ->where('created_user_id', $loginUser->id)
-            ->whereNotIn('id', $excludedIds)
+            ->whereDoesntHave('workflow_tables', function ($query) use ($today) {
+                $query->where('active_flg', 1)
+                    ->where(fn ($q) => $q->whereNull('active_start_date')
+                        ->orWhere('active_start_date', '<=', $today))
+                    ->where(fn ($q) => $q->whereNull('active_end_date')
+                        ->orWhere('active_end_date', '>=', $today))
+                    ->whereHas('workflow', fn ($q) => $q->where('setting_completed_flg', 1));
+            })
             ->pluck('table_name')
             ->toArray();
     }

--- a/src/Controllers/AiAssistantController.php
+++ b/src/Controllers/AiAssistantController.php
@@ -83,7 +83,7 @@ class AiAssistantController extends AdminControllerBase
             case 'workflow':
                 AssistantWorkflow::where('created_user_id', $loginUserID)->delete();
                 $model = AssistantWorkflow::create(['status' => 'init']);
-                $userCustomTables = $this->getUserCustomTablesAvaiable();
+                $userCustomTables = $this->getUserCustomTablesAvailable();
                 $welcomeMessage = exmtrans('ai_assistant.ai_response.workflow.welcome');
                 $welcomeMessage .= "\r\n" . implode("\n", $userCustomTables);
                 break;
@@ -397,7 +397,7 @@ class AiAssistantController extends AdminControllerBase
         ];
 
         if ($assistant_workflow->status === 'init') {
-            $userCustomTables = $this->getUserCustomTablesAvaiable();
+            $userCustomTables = $this->getUserCustomTablesAvailable();
             $payload['available_tables'] = json_encode($userCustomTables, JSON_THROW_ON_ERROR);
         }
 
@@ -646,16 +646,29 @@ class AiAssistantController extends AdminControllerBase
         return implode("\n", $lines);
     }
 
-    private function getUserCustomTablesAvaiable(): array
+    private function getUserCustomTablesAvailable(): array
     {
         $loginUser = \Exment::user();
+        $today = \Carbon\Carbon::today()->toDateString();
 
-        // CustomTable has Workflow List
+        // Exclude tables that currently have an active workflow
         $excludedIds = WorkflowTable::query()
+            ->where('active_flg', 1)
+            ->where(function ($query) use ($today) {
+                $query->whereNull('active_start_date')
+                    ->orWhereDate('active_start_date', '<=', $today);
+            })
+            ->where(function ($query) use ($today) {
+                $query->whereNull('active_end_date')
+                    ->orWhereDate('active_end_date', '>=', $today);
+            })
+            ->whereHas('workflow', function ($query) {
+                $query->where('setting_completed_flg', 1);
+            })
             ->pluck('custom_table_id')
+            ->unique()
             ->toArray();
 
-        // User's CustomTable not have Workflow
         return CustomTable::query()
             ->where('created_user_id', $loginUser->id)
             ->whereNotIn('id', $excludedIds)


### PR DESCRIPTION
> AI Assistant を使用してテーブルに対して WorkFlow を正常に作成した後、その WorkFlow を削除すると、その WorkFlow を削除されたテーブルが WorkFlow 作成をサポートするテーブル一覧に表示されなくなります。

上記のバグの修正