### PR TITLE
docs: update Operating environment to PHP 8.2 / Laravel 10

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -39,9 +39,9 @@ And more and more and more functions....
 
 ## Operating environment
 ### Server
-- PHP 7.3.0 or upper
-- MySQL 5.7.8 or upper and less than 8.0.0, or MariaDB 10.2.7 or upper
-- Laravel8.X
+- PHP 8.2.0 or upper
+- MySQL 5.7.8 or upper, or MariaDB 10.2.7 or upper
+- Laravel 10.X
 
 ### Support Browser
 - Google Chrome


### PR DESCRIPTION
## Summary

`ReadMe.md` の「Operating environment」セクションが古い記述のまま (PHP 7.3 / MySQL <8.0.0 / Laravel 8.X) になっていたので、現在の `composer.json` (php ^8.2.0 / laravel/framework ^10.34) と `Define::DATABASE_VERSION` (PR #1679 で MySQL の `max_lt` 上限を撤去) に合わせて更新しました。

| 項目 | Before | After |
|---|---|---|
| PHP | 7.3.0 or upper | 8.2.0 or upper |
| MySQL | 5.7.8 or upper and **less than 8.0.0** | 5.7.8 or upper |
| Laravel | Laravel8.X | Laravel 10.X |

## Test plan

- [x] 文言修正のみ。コード変更なし
- [x] `composer.json` の `php: ^8.2.0` と整合
- [x] `Define::DATABASE_VERSION` の `mysql.min = 5.7.8` (max なし) と整合
