### PR TITLE
ci: pin php-cs-fixer runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   php-cs-fixer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

`.github/workflows/php-cs-fixer.yml` だけ `ubuntu-latest` を使っていたので、他 3 ワークフロー (`phpstan.yml` / `unittest.yml` / `check-lang.yml`) と同じ `ubuntu-24.04` に揃えました。

`ubuntu-latest` は GitHub 側で参照先が切り替わる (現在は 22.04、将来的に 24.04 → 26.04 など) ため、ジョブ間で実行環境がずれる/突然挙動が変わるリスクがあります。固定値で揃えることで CI の再現性を担保します。

## Before / After

| workflow | Before | After |
|---|---|---|
| php-cs-fixer.yml | ubuntu-latest | ubuntu-24.04 |
| phpstan.yml | ubuntu-24.04 (no change) | ubuntu-24.04 |
| unittest.yml | ubuntu-24.04 (no change) | ubuntu-24.04 |
| check-lang.yml | ubuntu-24.04 (no change) | ubuntu-24.04 |

## Test plan

- [x] CI 設定の 1 行変更のみ。コードへの影響なし
- [ ] PR 上で `php-cs-fixer` ジョブが ubuntu-24.04 上で pass することを確認