### PR TITLE
feat: add coverage ci

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,92 @@
+name: coverage
+
+on:
+  pull_request:
+    paths:
+      - 'config/**'
+      - 'database/**'
+      - 'resources/**'
+      - 'src/**'
+      - 'tests/**'
+  push:
+    branches:
+      - master
+      - main
+
+env:
+  DOCKER_EXMENT_REPOSITORY: exceedone/docker-exment
+  EXMENT_BOILERPLATE_REPOSITORY: exceedone/exment-boilerplate
+
+jobs:
+  coverage:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ env.DOCKER_EXMENT_REPOSITORY }}
+          path: ./docker-exment
+
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ env.EXMENT_BOILERPLATE_REPOSITORY }}
+          path: ./docker-exment/exment-boilerplate
+
+      - uses: actions/checkout@v4
+        with:
+          path: ./docker-exment/exment-boilerplate/exment
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Docker Compose Version
+        run: docker compose --version
+
+      - name: Make mysql up
+        working-directory: docker-exment
+        run: make mysql-up
+
+      - name: Copy composer.dev.json
+        working-directory: docker-exment
+        run: |
+          docker compose -f docker-compose.yml exec -T php cp composer.dev.json composer.json
+          docker compose -f docker-compose.yml exec -T php cp composer.dev.lock composer.lock
+
+      - name: Initialize database and app
+        working-directory: docker-exment
+        run: make mysql-init
+
+      - name: Run unit + feature with coverage and merge
+        working-directory: docker-exment
+        run: make test-coverage
+
+      - name: Show coverage summary in job summary
+        working-directory: docker-exment
+        if: always()
+        run: |
+          {
+            echo "## Coverage (unit + feature merged)"
+            echo '```'
+            cat exment-boilerplate/storage/logs/coverage/merged/summary.txt || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-merged
+          path: |
+            docker-exment/exment-boilerplate/storage/logs/coverage/merged/clover.xml
+            docker-exment/exment-boilerplate/storage/logs/coverage/merged/html
+            docker-exment/exment-boilerplate/storage/logs/coverage/merged/summary.txt
+          if-no-files-found: warn
+          retention-days: 14
+
+      # Codecov upload. No token needed for public repos; for private repos add
+      # CODECOV_TOKEN to repository secrets.
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          files: docker-exment/exment-boilerplate/storage/logs/coverage/merged/clover.xml
+          flags: unit-feature
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,8 @@ on:
       - main
 
 env:
-  DOCKER_EXMENT_REPOSITORY: exceedone/docker-exment
+  # TEMP: point to fork branch until coverage tooling is merged into exceedone/docker-exment master
+  DOCKER_EXMENT_REPOSITORY: oreno4649/docker-exment
   EXMENT_BOILERPLATE_REPOSITORY: exceedone/exment-boilerplate
 
 jobs:
@@ -25,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ env.DOCKER_EXMENT_REPOSITORY }}
+          ref: feat/add-coverage
           path: ./docker-exment
 
       - uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,7 @@ name: coverage
 on:
   pull_request:
     paths:
+      - '.github/workflows/**'
       - 'config/**'
       - 'database/**'
       - 'resources/**'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,8 +15,7 @@ on:
       - main
 
 env:
-  # TEMP: point to fork branch until coverage tooling is merged into exceedone/docker-exment master
-  DOCKER_EXMENT_REPOSITORY: oreno4649/docker-exment
+  DOCKER_EXMENT_REPOSITORY: exceedone/docker-exment
   EXMENT_BOILERPLATE_REPOSITORY: exceedone/exment-boilerplate
 
 jobs:
@@ -26,7 +25,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ env.DOCKER_EXMENT_REPOSITORY }}
-          ref: feat/add-coverage
           path: ./docker-exment
 
       - uses: actions/checkout@v4

--- a/tests/Feature/NotifyTest.php
+++ b/tests/Feature/NotifyTest.php
@@ -208,6 +208,7 @@ class NotifyTest extends FeatureTestBase
         $data = NotifyNavbar::withoutGlobalScopes()
             ->where('target_user_id', $model->created_user_id)
             ->where('parent_type', $custom_table->table_name)
+            ->where('parent_id', $model->id)
             ->orderBy('created_at', 'desc')
             ->orderBy('id', 'desc')
             ->first();


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that runs the unit and feature test suites with PCOV code coverage, merges the results, publishes a summary, uploads artifacts, and sends the report to Codecov. Also fixes a flaky assertion in `NotifyTest::testNotifySchedule`.


ユニット/フィーチャーテストを PCOV でカバレッジ計測し、結果をマージして、サマリ表示・成果物アップロード・Codecov 連携まで行う GitHub Actions ワークフローを追加します。
あわせて `NotifyTest::testNotifySchedule` の flaky なアサーションを修正します。

## Changes

- **`.github/workflows/coverage.yml`
  - Triggers / トリガー: `pull_request` (paths: `.github/workflows/**`,
    `config/**`, `database/**`, `resources/**`, `src/**`, `tests/**`) and
    `push` to `master` / `main`
  - Runs `make test-coverage` (unit + feature via PCOV, then merge) using
    docker-exment + exment-boilerplate / docker-exment と exment-boilerplate を用いて `make test-coverage` （ユニット＋フィーチャーを PCOV 計測しマージ）を実行
  - Publishes the coverage summary to the job summary / カバレッジサマリをジョブサマリに出力
  - Uploads merged artifacts (`clover.xml`, `html`, `summary.txt`), 14-day retention / マージ済み成果物をアップロード（保持14日）
  - Uploads coverage to Codecov (flag `unit-feature`) / Codecov にアップロード（flag `unit-feature`）
- **`tests/Feature/NotifyTest.php`**
  - Scope the `NotifyNavbar` lookup to the target record
    (`->where('parent_id', $model->id)`). The previous "latest entry"
    lookup was non-deterministic because seeded date values use `rand()`
    relative to today, so other records occasionally fell into the notify
    window and produced a newer entry, breaking the assertion.
  - NotifyNavbar` の取得を対象レコードに限定
    (`->where('parent_id', $model->id)`)。従来は「最新1件」を取得していたため、
    シードの日付が今日基準の `rand()` で生成される関係上、他レコードの通知が
    通知ウィンドウに割り込んで新しいエントリを作り、アサーションが不安定でした。

## Dependency 
The `make test-coverage` target (and the PCOV toolchain) lives in
`docker-exment`. This workflow checks out `exceedone/docker-exment@master`,
so the coverage job only passes once the coverage tooling is merged into
`exceedone/docker-exment` master.

`make test-coverage`（および PCOV ツールチェーン）は `docker-exment` 側にあります。本ワークフローは `exceedone/docker-exment@master` を取得するため、docker-exment のカバレッジ対応が master にマージされるまで coverage ジョブは成功しません。

https://github.com/exceedone/docker-exment/pull/16
