### PR TITLE
test: add pure unit tests for Validator rules

### DIFF
--- a/tests/Unit/Pure/BooleanRuleTest.php
+++ b/tests/Unit/Pure/BooleanRuleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit\Pure;
+
+use Exceedone\Exment\Validator\BooleanRule;
+
+class BooleanRuleTest extends PureTestBase
+{
+    /**
+     * Mirrors the real option shape built by Boolean::getImportValueOption():
+     * [ storedValue => displayLabel, ... ]. passes() accepts either the key
+     * (stored value) or the value (label).
+     *
+     * @return BooleanRule
+     */
+    private function rule(): BooleanRule
+    {
+        return new BooleanRule(['0' => 'No', '1' => 'Yes']);
+    }
+
+    public function testNullPasses(): void
+    {
+        $this->assertTrue($this->rule()->passes('attr', null));
+    }
+
+    public function testStoredValueMatchesKey(): void
+    {
+        $this->assertTrue($this->rule()->passes('attr', '0'));
+        $this->assertTrue($this->rule()->passes('attr', '1'));
+    }
+
+    public function testLabelMatchesValue(): void
+    {
+        $this->assertTrue($this->rule()->passes('attr', 'No'));
+        $this->assertTrue($this->rule()->passes('attr', 'Yes'));
+    }
+
+    public function testUnknownValueFails(): void
+    {
+        $this->assertFalse($this->rule()->passes('attr', 'maybe'));
+    }
+}

--- a/tests/Unit/Pure/BooleanRuleTest.php
+++ b/tests/Unit/Pure/BooleanRuleTest.php
@@ -15,7 +15,10 @@ class BooleanRuleTest extends PureTestBase
      */
     private function rule(): BooleanRule
     {
-        return new BooleanRule(['0' => 'No', '1' => 'Yes']);
+        /** @var array<string, mixed> $option */
+        $option = ['0' => 'No', '1' => 'Yes'];
+
+        return new BooleanRule($option);
     }
 
     public function testNullPasses(): void

--- a/tests/Unit/Pure/DecimalCommaRuleTest.php
+++ b/tests/Unit/Pure/DecimalCommaRuleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit\Pure;
+
+use Exceedone\Exment\Validator\DecimalCommaRule;
+
+class DecimalCommaRuleTest extends PureTestBase
+{
+    public function testDecimalWithCommaPasses(): void
+    {
+        $this->assertTrue((bool)(new DecimalCommaRule())->passes('attr', '1,234.56'));
+    }
+
+    public function testNegativeDecimalPasses(): void
+    {
+        $this->assertTrue((bool)(new DecimalCommaRule())->passes('attr', '-12.3'));
+    }
+
+    public function testAlphabeticFails(): void
+    {
+        $this->assertFalse((bool)(new DecimalCommaRule())->passes('attr', 'abc'));
+    }
+
+    public function testArrayFails(): void
+    {
+        $this->assertFalse((new DecimalCommaRule())->passes('attr', ['1.0']));
+    }
+}

--- a/tests/Unit/Pure/EmptyRuleTest.php
+++ b/tests/Unit/Pure/EmptyRuleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit\Pure;
+
+use Exceedone\Exment\Validator\EmptyRule;
+
+class EmptyRuleTest extends PureTestBase
+{
+    public function testNullPasses(): void
+    {
+        $this->assertTrue((new EmptyRule())->passes('attr', null));
+    }
+
+    public function testEmptyStringPasses(): void
+    {
+        $this->assertTrue((new EmptyRule())->passes('attr', ''));
+    }
+
+    public function testZeroPasses(): void
+    {
+        $this->assertTrue((new EmptyRule())->passes('attr', '0'));
+    }
+
+    public function testNonEmptyFails(): void
+    {
+        $this->assertFalse((new EmptyRule())->passes('attr', 'abc'));
+    }
+}

--- a/tests/Unit/Pure/IntegerCommaRuleTest.php
+++ b/tests/Unit/Pure/IntegerCommaRuleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit\Pure;
+
+use Exceedone\Exment\Validator\IntegerCommaRule;
+
+class IntegerCommaRuleTest extends PureTestBase
+{
+    public function testIntegerWithCommaPasses(): void
+    {
+        $this->assertTrue((bool)(new IntegerCommaRule())->passes('attr', '1,234'));
+    }
+
+    public function testNegativeIntegerPasses(): void
+    {
+        $this->assertTrue((bool)(new IntegerCommaRule())->passes('attr', '-100'));
+    }
+
+    public function testDecimalFails(): void
+    {
+        $this->assertFalse((bool)(new IntegerCommaRule())->passes('attr', '1.5'));
+    }
+
+    public function testArrayFails(): void
+    {
+        $this->assertFalse((new IntegerCommaRule())->passes('attr', ['1']));
+    }
+}

--- a/tests/Unit/Pure/MaxLengthExRuleTest.php
+++ b/tests/Unit/Pure/MaxLengthExRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit\Pure;
+
+use Exceedone\Exment\Validator\MaxLengthExRule;
+
+class MaxLengthExRuleTest extends PureTestBase
+{
+    public function testNullPasses(): void
+    {
+        $this->assertTrue((new MaxLengthExRule(5))->passes('attr', null));
+    }
+
+    public function testUnderMaxPasses(): void
+    {
+        $this->assertTrue((new MaxLengthExRule(5))->passes('attr', 'abc'));
+    }
+
+    public function testEqualMaxPasses(): void
+    {
+        $this->assertTrue((new MaxLengthExRule(3))->passes('attr', 'abc'));
+    }
+
+    public function testOverMaxFails(): void
+    {
+        $this->assertFalse((new MaxLengthExRule(3))->passes('attr', 'abcd'));
+    }
+
+    public function testCrlfCountedAsSingleChar(): void
+    {
+        // "a\r\nb" -> normalized to "a\nb" = 3 chars
+        $this->assertTrue((new MaxLengthExRule(3))->passes('attr', "a\r\nb"));
+    }
+}

--- a/tests/Unit/Pure/NumberMaxRuleTest.php
+++ b/tests/Unit/Pure/NumberMaxRuleTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit\Pure;
+
+use Exceedone\Exment\Validator\NumberMaxRule;
+
+class NumberMaxRuleTest extends PureTestBase
+{
+    public function testNullPasses(): void
+    {
+        $this->assertTrue((new NumberMaxRule(100))->passes('attr', null));
+    }
+
+    public function testNonNumericPasses(): void
+    {
+        $this->assertTrue((new NumberMaxRule(100))->passes('attr', 'abc'));
+    }
+
+    public function testValueWithCommaUnderMaxPasses(): void
+    {
+        $this->assertTrue((new NumberMaxRule(2000))->passes('attr', '1,500'));
+    }
+
+    public function testValueOverMaxFails(): void
+    {
+        $this->assertFalse((new NumberMaxRule(100))->passes('attr', '101'));
+    }
+
+    public function testValueEqualMaxPasses(): void
+    {
+        $this->assertTrue((new NumberMaxRule(100))->passes('attr', '100'));
+    }
+}

--- a/tests/Unit/Pure/NumberMinRuleTest.php
+++ b/tests/Unit/Pure/NumberMinRuleTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit\Pure;
+
+use Exceedone\Exment\Validator\NumberMinRule;
+
+class NumberMinRuleTest extends PureTestBase
+{
+    public function testNullPasses(): void
+    {
+        $this->assertTrue((new NumberMinRule(0))->passes('attr', null));
+    }
+
+    public function testNonNumericPasses(): void
+    {
+        $this->assertTrue((new NumberMinRule(0))->passes('attr', 'abc'));
+    }
+
+    public function testValueWithCommaOverMinPasses(): void
+    {
+        $this->assertTrue((new NumberMinRule(1000))->passes('attr', '1,500'));
+    }
+
+    public function testValueUnderMinFails(): void
+    {
+        $this->assertFalse((new NumberMinRule(100))->passes('attr', '99'));
+    }
+
+    public function testValueEqualMinPasses(): void
+    {
+        $this->assertTrue((new NumberMinRule(100))->passes('attr', '100'));
+    }
+}

--- a/tests/Unit/Pure/PureTestBase.php
+++ b/tests/Unit/Pure/PureTestBase.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit\Pure;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Lightweight base class for "pure" unit tests.
+ *
+ * These tests do NOT boot the Laravel application, connect to a database,
+ * or use the service container. They exercise pure logic only (e.g. the
+ * passes() methods of Validator rules), so they run in milliseconds.
+ *
+ * The Exment global helpers (isMatchString, is_list, rmcomma, ...) live in
+ * src/Services/Helpers.php and are normally required by ExmentServiceProvider
+ * at boot time. Since we skip booting, we require that file once here.
+ * The lower-level *_ex helpers (strcmp_ex, ...) come from laravel-admin and
+ * are already autoloaded via composer "files".
+ */
+abstract class PureTestBase extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        require_once __DIR__ . '/../../../src/Services/Helpers.php';
+    }
+}

--- a/tests/Unit/Pure/StringNumericRuleTest.php
+++ b/tests/Unit/Pure/StringNumericRuleTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit\Pure;
+
+use Exceedone\Exment\Validator\StringNumericRule;
+
+class StringNumericRuleTest extends PureTestBase
+{
+    public function testNullPasses(): void
+    {
+        $this->assertTrue((new StringNumericRule())->passes('attr', null));
+    }
+
+    public function testStringPasses(): void
+    {
+        $this->assertTrue((new StringNumericRule())->passes('attr', 'abc'));
+    }
+
+    public function testNumericPasses(): void
+    {
+        $this->assertTrue((new StringNumericRule())->passes('attr', 123));
+    }
+
+    public function testArrayFails(): void
+    {
+        $this->assertFalse((new StringNumericRule())->passes('attr', ['a']));
+    }
+}

--- a/tests/Unit/Pure/YesNoRuleTest.php
+++ b/tests/Unit/Pure/YesNoRuleTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit\Pure;
+
+use Exceedone\Exment\Validator\YesNoRule;
+
+class YesNoRuleTest extends PureTestBase
+{
+    public function testNullPasses(): void
+    {
+        $this->assertTrue((new YesNoRule())->passes('attr', null));
+    }
+
+    public function testBooleanPasses(): void
+    {
+        $this->assertTrue((new YesNoRule())->passes('attr', true));
+        $this->assertTrue((new YesNoRule())->passes('attr', false));
+    }
+
+    /**
+     * @dataProvider acceptedProvider
+     */
+    public function testAcceptedStringsPass($value): void
+    {
+        $this->assertTrue((new YesNoRule())->passes('attr', $value));
+    }
+
+    public static function acceptedProvider(): array
+    {
+        return [['0'], ['1'], ['yes'], ['no'], ['YES'], ['NO'], ['true'], ['false']];
+    }
+
+    public function testUnknownValueFails(): void
+    {
+        $this->assertFalse((new YesNoRule())->passes('attr', 'maybe'));
+    }
+}

--- a/tests/Unit/Pure/YesNoRuleTest.php
+++ b/tests/Unit/Pure/YesNoRuleTest.php
@@ -20,11 +20,14 @@ class YesNoRuleTest extends PureTestBase
     /**
      * @dataProvider acceptedProvider
      */
-    public function testAcceptedStringsPass($value): void
+    public function testAcceptedStringsPass(string $value): void
     {
         $this->assertTrue((new YesNoRule())->passes('attr', $value));
     }
 
+    /**
+     * @return array<int, array<int, string>>
+     */
     public static function acceptedProvider(): array
     {
         return [['0'], ['1'], ['yes'], ['no'], ['YES'], ['NO'], ['true'], ['false']];


### PR DESCRIPTION
  ## Summary

  Adds lightweight "pure" unit tests for the `Validator` rules. These tests
  exercise only the `passes()` logic of each rule, so they run **without
  booting the Laravel application, connecting to a database, or using the
  service container** — the full 46-test suite finishes in ~22ms.

  ## What's included

  ### `tests/Unit/Pure/PureTestBase.php`
  A new lightweight base class that extends PHPUnit's `TestCase` directly
  (not the app's `Tests\TestCase`). It only requires `src/Services/Helpers.php`
  once so the Exment global helpers (`isMatchString`, `is_list`, `rmcomma`)
  are available. The lower-level `*_ex` helpers (`strcmp_ex`, ...) are already
  autoloaded via laravel-admin's composer `files`.

  ### Unit tests for 9 pure Validator rules
  | Rule | Covered |
  |------|---------|
  | `BooleanRule` | null / stored value (key) / label (value) / unknown |
  | `NumberMaxRule` | null / non-numeric / comma value / over / equal |
  | `NumberMinRule` | null / non-numeric / comma value / under / equal |
  | `DecimalCommaRule` | decimal w/ comma / negative / alphabetic / array |
  | `IntegerCommaRule` | comma value / negative / decimal / array |
  | `MaxLengthExRule` | null / under / equal / over / CRLF normalization |
  | `StringNumericRule` | null / string / numeric / array |
  | `YesNoRule` | null / boolean / 8 accepted strings / unknown |
  | `EmptyRule` | null / empty string / "0" / non-empty |

  ## Notes

  - Test inputs mirror real construction (e.g. `BooleanRule`'s
    `storedValue => label` option shape from `Boolean::getImportValueOption()`,
    comma-separated numbers passed to `NumberMin/MaxRule`).
  - The `message()` path is intentionally **out of scope** because it depends on
    the translator (`trans()` / `exmtrans()`), which would require booting the app.
  - `passes()` of `DecimalCommaRule` / `IntegerCommaRule` returns `preg_match`'s
    int; tests cast to bool. The "non-numeric passes" behavior of
    `NumberMin/MaxRule` is intentional (type checks are handled by other rules)
    and is documented in the tests.


  ## 概要

  `Validator` ルール向けに軽量な「純粋」ユニットテストを追加します。各ルールの
  `passes()` ロジックのみを検証するため、**Laravel アプリの起動・DB 接続・サービス
  コンテナを一切使わず**に実行でき、全46テストが約22msで完了します。

  ## 含まれるもの

  ### `tests/Unit/Pure/PureTestBase.php`
  PHPUnit の `TestCase` を直接継承（アプリの `Tests\TestCase` は継承しない）した
  軽量基底クラス。`src/Services/Helpers.php` を一度だけ require することで、Exment の
  グローバルヘルパ（`isMatchString` / `is_list` / `rmcomma`）を利用可能にします。
  より低レベルの `*_ex` ヘルパ（`strcmp_ex` 等）は laravel-admin の composer `files`
  により既に autoload されています。

  ### 純粋な Validator ルール9種のユニットテスト
  | ルール | 検証内容 |
  |--------|----------|
  | `BooleanRule` | null / 格納値(キー) / ラベル(値) / 未知の値 |
  | `NumberMaxRule` | null / 非数値 / カンマ付き / 上限超過 / 上限一致 |
  | `NumberMinRule` | null / 非数値 / カンマ付き / 下限未満 / 下限一致 |
  | `DecimalCommaRule` | カンマ付き小数 / 負数 / 英字 / 配列 |
  | `IntegerCommaRule` | カンマ付き / 負数 / 小数 / 配列 |
  | `MaxLengthExRule` | null / 上限未満 / 上限一致 / 超過 / CRLF正規化 |
  | `StringNumericRule` | null / 文字列 / 数値 / 配列 |
  | `YesNoRule` | null / 真偽値 / 許容8表現 / 未知の値 |
  | `EmptyRule` | null / 空文字 / "0" / 非空 |

  ## 補足

  - テスト入力は実際の生成方法に合わせています（例：`Boolean::getImportValueOption()`
    が返す `格納値 => ラベル` 形式、`NumberMin/MaxRule` に渡すカンマ区切り数値など）。
  - `message()` の経路はトランスレータ（`trans()` / `exmtrans()`）依存でアプリ起動を
    要するため、**対象外**としています。
  - `DecimalCommaRule` / `IntegerCommaRule` の `passes()` は `preg_match` の int を
    返すためテスト側で bool にキャストしています。`NumberMin/MaxRule` の「非数値は
    通過」挙動は仕様（型検査は別ルールが担当）であり、テスト内に明記しています。