### PR TITLE
Fix zero-padded values in array column matches

### DIFF
--- a/src/Database/Query/Grammars/MySqlGrammar.php
+++ b/src/Database/Query/Grammars/MySqlGrammar.php
@@ -105,7 +105,7 @@ class MySqlGrammar extends BaseGrammar implements GrammarInterface
     public function whereInArrayColumn($builder, string $tableName, string $baseColumn, string $column, bool $isOr = false, bool $isNot = false)
     {
         $index = $this->wrap($column);
-        $baseColumnIndex = $this->wrap($baseColumn);
+        $baseColumnIndex = "CAST({$this->wrap($baseColumn)} AS CHAR)";
 
         if ($isNot) {
             $queryStr = "NOT FIND_IN_SET({$baseColumnIndex}, IFNULL(REPLACE(REPLACE(REPLACE(REPLACE($index, '[', ''), ' ', ''), ']', ''), '\\\"', ''), ''))";

--- a/tests/Unit/MySqlGrammarTest.php
+++ b/tests/Unit/MySqlGrammarTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Exceedone\Exment\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Exceedone\Exment\Database\Query\Grammars\MySqlGrammar;
+
+class MySqlGrammarTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testWhereInArrayColumnCastsTheMatchColumnToText()
+    {
+        $builder = new class() {
+            public string $sql = '';
+
+            public function whereRaw(string $sql)
+            {
+                $this->sql = $sql;
+
+                return $this;
+            }
+        };
+
+        $grammar = new MySqlGrammar();
+        $grammar->whereInArrayColumn($builder, 'items', 'source.code', 'target.codes');
+
+        $this->assertSame(
+            'FIND_IN_SET(CAST(`source`.`code` AS CHAR), REPLACE(REPLACE(REPLACE(REPLACE(`target`.`codes`, \'[\', \'\'), \' \', \'\'), \']\', \'\'), \'\\"\', \'\'))',
+            $builder->sql
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Cast the wrapped match column to `CHAR` before passing it to `FIND_IN_SET`. This preserves zero-padded option values such as `01` in paginated array-column matching, keeping the row query consistent with the string-bound count query.

Fixes #1718.

## Changes

- Apply the cast in the shared expression used by normal and negated array-column matches.
- Add a focused SQL-generation regression test that verifies both identifier wrapping and string semantics.

## Testing

- Focused PHPUnit regression: 1 test, 1 assertion
- PHP-CS-Fixer 3.95.13: 2 changed files, no fixes needed
- PHP syntax checks for both changed files
- `composer validate --no-check-publish`
- `git diff --check`

The full Dockerized Laravel/MariaDB integration environment was not available locally, so repository CI remains the source of truth for that coverage.
